### PR TITLE
fix(warnings): resolve character truncation warnings

### DIFF
--- a/src/gwf2gag7.f
+++ b/src/gwf2gag7.f
@@ -166,8 +166,8 @@ C     ------------------------------------------------------------------
       CHARACTER*1 A
       CHARACTER*2 B
       CHARACTER*7 CONCNAME
-      CHARACTER*9 DCTSNAME
-      CHARACTER*10 DCCMNAME
+      CHARACTER*11 DCTSNAME
+      CHARACTER*12 DCCMNAME
       CHARACTER*1256  LFRMAT
 C     ------------------------------------------------------------------
 C     TEMPORARY ARRAYS

--- a/src/gwf2swr7.f
+++ b/src/gwf2swr7.f
@@ -3818,7 +3818,7 @@ C           TO SPECIFY STRCRIT OR STRVAL
                   CASE (1)
                     cstruct(1) = 'STRCRIT   '
                   CASE (2)
-                    cstruct(1) = 'STRVAL     '
+                    cstruct(1) = 'STRVAL    '
                   CASE DEFAULT
                     CALL USTOP('PROGRAMMING ERROR: UNDEFINED ISTRTYPE')
                 END SELECT

--- a/src/pcgn2.f90
+++ b/src/pcgn2.f90
@@ -104,7 +104,7 @@ CONTAINS
           STOP
        ELSE
           IF (LEN_TRIM(CHAR_STRING)==0) CYCLE
-          CHECK=CHAR_STRING
+          CHECK=CHAR_STRING(1:1)
           IF (CHECK=='#') CYCLE
           L_COUNT=L_COUNT+1
           DATA_STRING(L_COUNT)=TRIM(CHAR_STRING)


### PR DESCRIPTION
This PR resolves a few gfortran compiler warnings using `-Wcharacter-truncation`:
```
/home/mtoews/src/mf2005/src/gwf2gag7.f:382:72:

                        DCTSNAME(ISOL)='Del-C'//'_0'//A//'-TS'
                                                                        1
Warning: CHARACTER expression will be truncated in assignment (9/11) at (1) [-Wcharacter-truncation]
/home/mtoews/src/mf2005/src/gwf2gag7.f:383:72:

                        DCCMNAME(ISOL)='Del-C'//'_0'//A//'-Cum'
                                                                        1
Warning: CHARACTER expression will be truncated in assignment (10/12) at (1) [-Wcharacter-truncation]
/home/mtoews/src/mf2005/src/gwf2gag7.f:389:72:

                        DCTSNAME(ISOL)='Del-C'//'_'//B//'-TS'
                                                                        1
Warning: CHARACTER expression will be truncated in assignment (9/11) at (1) [-Wcharacter-truncation]
/home/mtoews/src/mf2005/src/gwf2gag7.f:390:72:

                        DCCMNAME(ISOL)='Del-C'//'_'//B//'-Cum'
                                                                        1
Warning: CHARACTER expression will be truncated in assignment (10/12) at (1) [-Wcharacter-truncation]
/home/mtoews/src/mf2005/src/gwf2swr7.f:3821:72:

                     cstruct(1) = 'STRVAL     '
                                                                        1
Warning: CHARACTER expression will be truncated in assignment (10/11) at (1) [-Wcharacter-truncation]
/home/mtoews/src/mf2005/src/pcgn2.f90:107:27:

           CHECK=CHAR_STRING
                           1
Warning: CHARACTER expression will be truncated in assignment (1/256) at (1) [-Wcharacter-truncation]
```
The resolutions are:
* gwf2gag7.f: increase DCTSNAME from 9 to 11, and DCCMNAME from 10 to 12
* gwf2swr7.f: remove space for cstruct(1)
* pcgn2.f90: cut CHAR_STRING to 1