### PR TITLE
restore flush, but only main output unit

### DIFF
--- a/src/mf2005.f
+++ b/src/mf2005.f
@@ -745,7 +745,7 @@ C     Write times to file if requested
 C
 C     Ensure output file is written (needed on macOS to flush buffers before exit)
 C     Flush only IOUT to avoid access violations with stream-access binary files on Intel compiler
-      CALL FLUSH(IOUT)
+      CALL FLUSH()!(IOUT)
 C
       RETURN
       END

--- a/src/mf2005.f
+++ b/src/mf2005.f
@@ -743,5 +743,9 @@ C     Write times to file if requested
         ENDIF
       ENDIF
 C
+C     Ensure output file is written (needed on macOS to flush buffers before exit)
+C     Flush only IOUT to avoid access violations with stream-access binary files on Intel compiler
+      CALL FLUSH(IOUT)
+C
       RETURN
       END

--- a/src/mf2005.f
+++ b/src/mf2005.f
@@ -743,9 +743,9 @@ C     Write times to file if requested
         ENDIF
       ENDIF
 C
-C     Ensure output file is written (needed on macOS to flush buffers before exit)
-C     Flush only IOUT to avoid access violations with stream-access binary files on Intel compiler
-      CALL FLUSH()!(IOUT)
+C     Ensure output file is written on macOS/gfortran, but flush only IOUT to avoid
+C     access violations with stream-access binary files using ifx on linux/windows.
+      CALL FLUSH(IOUT)
 C
       RETURN
       END


### PR DESCRIPTION
#54 removed the `flush` statement at the end of `mf2005.f`, I didn't see the history in #50 and https://github.com/modflowpy/pymake/issues/97. Flushing everything causes access violations with ifx, I think because it tries to flush binary files too... seems like we are squeezed here between a gfortran/mac bug and an ifx/other platforms bug. Try restoring the statement but only flush the main output unit, hopefully the problem only affected the program's main output, not binary output files too.