### PR TITLE
fix(mnw): avoid overflow

### DIFF
--- a/src/gwf2mnw27.f
+++ b/src/gwf2mnw27.f
@@ -2177,8 +2177,8 @@ c             Q has been constrained
              else
 c             only perform % checks after second iteration (lets soln get going)
               if(kiter.gt.2) then
-c              % check divides by lastQ, so avoid this if it is zero
-               if(lastQ.ne.0.0) then
+c              % check divides by lastQ, so avoid this if it is zero or very small
+               if(abs(lastQ).gt.1.0d-30) then
 c               this is the percentage change, below which the Q will be locked in
 c               for the time step
                 temppct=0.01d0

--- a/src/gwf2mnw27.f
+++ b/src/gwf2mnw27.f
@@ -2177,13 +2177,14 @@ c             Q has been constrained
              else
 c             only perform % checks after second iteration (lets soln get going)
               if(kiter.gt.2) then
-c              % check divides by lastQ, so avoid this if it is zero or very small
-               if(abs(lastQ).gt.1.0d-30) then
+c              % check divides by lastQ, so avoid this if it is zero
+               if(lastQ.ne.0.0d0) then
 c               this is the percentage change, below which the Q will be locked in
 c               for the time step
                 temppct=0.01d0
 c               calculated % change in Q looked up in capacity tables
-                qtemp=abs(qactCap-lastQ)/abs(lastQ)
+c               protect against overflow by clamping denominator
+                qtemp=abs(qactCap-lastQ)/max(abs(lastQ),1.0d-100)
 c
 c               if Q is changing more than 1%, continue
                 if (qtemp.gt.temppct) then


### PR DESCRIPTION
to avoid overflow, incidence of which varies by platform/compiler, don't divide by very small numbers, clamp dividend to 1e-100. previously logic only avoided division by 0. fix [failing CI tests on Windows / Intel Fortran](github.com/MODFLOW-ORG/mf2005/actions/runs/21781299542/job/62863657356#step:14:156)